### PR TITLE
Update msbuilder.py

### DIFF
--- a/modelseedpy/core/msbuilder.py
+++ b/modelseedpy/core/msbuilder.py
@@ -466,7 +466,7 @@ class MSBuilder:
                 complete &= len(complx[3]) > 0 or not complx[1] or complx[2]
                 if len(complx[3]) > 0:
                     roles.add(role_id)
-                    role_genes[role_id] = t[3]
+                    role_genes[role_id] = complx[3]
             # print(cpx_id, complete, roles)
             if len(roles) > 0 and (allow_incomplete_complexes or complete):
                 complexes[cpx_id] = {}

--- a/modelseedpy/core/msbuilder.py
+++ b/modelseedpy/core/msbuilder.py
@@ -443,12 +443,12 @@ class MSBuilder:
             for role, (triggering, optional) in cpx.roles.items():
                 rn_norm = normalize_role(role.name)
                 template_reaction_complexes[cpx.id][role.id] = [
-                    sn,
+                    rn_norm,
                     triggering,
                     optional,
                     set()
-                    if sn not in self.search_name_to_genes
-                    else set(self.search_name_to_genes[sn]),
+                    if rn_norm not in self.search_name_to_genes
+                    else set(self.search_name_to_genes[rn_norm]),
                 ]
         return template_reaction_complexes
 


### PR DESCRIPTION
The MSBuilder method _get_template_reaction_complexes has an undefined variable sn that causes an error when I try to run the example code at 

https://github.com/freiburgermsu/ModelSEEDpy/blob/f546097837a9f69f2e35c7374264a21836bf6e26/docs/source/model_reconstruction/build_metabolic_model.ipynb

Looks like occurrences of sn should be replaced by rn_norm. Having done that I now have a different error when I attempt to run the code.  

I'd appreciate any advice on the modelseedpy package: 
Is your fork the most functional (seems much better than the original)? 
Is development still active/ongoing? 
Do you recommend another package for creating draft metabolic models? 

Thanks.
